### PR TITLE
CC API update & Python3

### DIFF
--- a/crypto_compare/apis/helper.py
+++ b/crypto_compare/apis/helper.py
@@ -1,5 +1,5 @@
 import json
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 
 ALLOWED_KEYS = [
     'fsym',
@@ -8,16 +8,19 @@ ALLOWED_KEYS = [
     'tsyms',
     'ts',
     'e',
+    'limit',
     'markets',
     'extraParams',
     'sign',
+    'tots',
+    'toTs',
     'tryConversion',
     'calculationType'
 ]
 
 def _is_params_valid(self, **kwargs):
 
-    for key,value in kwargs.items():
+    for key,value in list(kwargs.items()):
         if(value == None or value == ''):
             raise ValueError(key+' cannot be empty!')
 
@@ -28,7 +31,7 @@ def _fetch_data(self, url):
 
     print('Calling URL - ' + url)
     
-    json_response = json.load(urllib2.urlopen(url))
+    json_response = json.load(urllib.request.urlopen(url))
     
     if 'Response' in json_response and json_response["Response"] == 'Error':
         raise ValueError("API Error - {} !".format(json_response['Message']))
@@ -43,7 +46,7 @@ def _get_querystring(self, kwargs):
 
     if kwargs is not None:
         
-        for key,value in kwargs.items():
+        for key,value in list(kwargs.items()):
             
             if key == "fsym" or key == "fsyms":
                 fsym = value
@@ -53,4 +56,4 @@ def _get_querystring(self, kwargs):
             if key in ALLOWED_KEYS:
                 querystring = "{}&{}".format(querystring, "{}={}".format(key, value))
             
-    return fsym, tsym, querystring
+    return fsym, tsym, querystring + '&apikey=' + self.apikey

--- a/crypto_compare/apis/helper.py
+++ b/crypto_compare/apis/helper.py
@@ -29,7 +29,7 @@ def _is_params_valid(self, **kwargs):
 
 def _fetch_data(self, url):
 
-    print('Calling URL - ' + url)
+    #print('Calling URL - ' + url)
     
     json_response = json.load(urllib.request.urlopen(url))
     

--- a/crypto_compare/client.py
+++ b/crypto_compare/client.py
@@ -1,34 +1,38 @@
 
 class Client:
+    def __init__(self, apikey):
+        self.apikey = apikey
+
+    BASE_URL = 'https://min-api.cryptocompare.com'
     
-    COIN_LIST_URL = 'https://www.cryptocompare.com/api/data/coinlist/'
+    COIN_LIST_URL = BASE_URL + '/data/all/coinlist'
     COIN_SNAPSHOT_FULL_BY_ID_URL = 'https://www.cryptocompare.com/api/data/coinsnapshotfullbyid/?id='
-    COIN_SNAPSHOT_URL  = 'https://www.cryptocompare.com/api/data/coinsnapshot/'
+    COIN_SNAPSHOT_URL  = BASE_URL + '/data/top/exchanges/full'
 
-    PRICE_URL = 'https://min-api.cryptocompare.com/data/price'
-    PRICE_MULTI_URL = 'https://min-api.cryptocompare.com/data/pricemulti'
-    PRICE_MULTI_FULL_URL = 'https://min-api.cryptocompare.com/data/pricemultifull'
-    PRICE_HISTORICAL_URL = 'https://min-api.cryptocompare.com/data/pricehistorical'
+    PRICE_URL = BASE_URL + '/data/price'
+    PRICE_MULTI_URL = BASE_URL + '/data/pricemulti'
+    PRICE_MULTI_FULL_URL = BASE_URL + '/data/pricemultifull'
+    PRICE_HISTORICAL_URL = BASE_URL + '/data/pricehistorical'
 
-    GENERATE_AVG_URL = 'https://min-api.cryptocompare.com/data/generateAvg'
-    DAY_AVG_URL = 'https://min-api.cryptocompare.com/data/dayAvg'
+    GENERATE_AVG_URL = BASE_URL + '/data/generateAvg'
+    DAY_AVG_URL = BASE_URL + '/data/dayAvg'
 
-    SUBS_WATCH_LIST_URL = 'https://min-api.cryptocompare.com/data/subsWatchlist'
-    SUBS_URL = 'https://min-api.cryptocompare.com/data/subs'
+    SUBS_WATCH_LIST_URL = BASE_URL + '/data/subsWatchlist'
+    SUBS_URL = BASE_URL + '/data/subs'
 
-    ALL_EXCHANGES_URL = 'https://min-api.cryptocompare.com/data/all/exchanges'
-    TOP_EXCHANGES_URL = 'https://min-api.cryptocompare.com/data/top/exchanges'
+    ALL_EXCHANGES_URL = BASE_URL + '/data/all/exchanges'
+    TOP_EXCHANGES_URL = BASE_URL + '/data/top/exchanges'
     TOP_VOLUMES_URL = 'https://min-api.cryptocompare.com/data/top/volumes'
     TOP_PAIRS_URL = 'https://min-api.cryptocompare.com/data/top/pairs'
 
-    HISTO_DAY_URL = 'https://min-api.cryptocompare.com/data/histoday'
-    HISTO_HOUR_URL = 'https://min-api.cryptocompare.com/data/histohour'
-    HISTO_MINUTE_URL = 'https://min-api.cryptocompare.com/data/histominute'
+    HISTO_DAY_URL = BASE_URL + '/data/histoday'
+    HISTO_HOUR_URL = BASE_URL + '/data/histohour'
+    HISTO_MINUTE_URL = BASE_URL + '/data/histominute'
 
     SOCIAL_STATS_URL = 'https://www.cryptocompare.com/api/data/socialstats?id='
 
-    MINING_CONTRACTS_URL = 'https://www.cryptocompare.com/api/data/miningcontracts/'
-    MINING_EQUIPMENT_URL = 'https://www.cryptocompare.com/api/data/miningequipment/'
+    MINING_CONTRACTS_URL = BASE_URL + '/data/mining/contracts/general'
+    MINING_EQUIPMENT_URL = BASE_URL + '/data/mining/equipment/general'
 
     from .apis.coin import coin_list, coin_snapshot_full_by_id, coin_snapshot
     from .apis.price import price, price_multi, price_multifull, price_historical

--- a/crypto_compare/client.py
+++ b/crypto_compare/client.py
@@ -22,8 +22,8 @@ class Client:
 
     ALL_EXCHANGES_URL = BASE_URL + '/data/all/exchanges'
     TOP_EXCHANGES_URL = BASE_URL + '/data/top/exchanges'
-    TOP_VOLUMES_URL = 'https://min-api.cryptocompare.com/data/top/volumes'
-    TOP_PAIRS_URL = 'https://min-api.cryptocompare.com/data/top/pairs'
+    TOP_VOLUMES_URL = BASE_URL + '/data/top/volumes'
+    TOP_PAIRS_URL = BASE_URL + '/data/top/pairs'
 
     HISTO_DAY_URL = BASE_URL + '/data/histoday'
     HISTO_HOUR_URL = BASE_URL + '/data/histohour'

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 with open('README.rst') as f:
     readme = f.read()
@@ -13,8 +13,8 @@ setup(
         author_email='parth.barot@botreetechnologies.com',
         keywords='crypto cryptocurrency wrapper cryptocompare crypto_compare',
         license='MIT',
-        python_requires='>=2.7',
-        packages=['crypto_compare'],
-        classifiers=['Programming Language :: Python :: 2.7'],
-        install_requires=['urllib2', 'pytest']
+        python_requires='>=3.6',
+        packages=find_packages(),
+        classifiers=['Programming Language :: Python :: 3.6'],
+        install_requires=['urllib3', 'pytest']
     )


### PR DESCRIPTION
This updates the code to work with Python3, preferably >3.6 for asyncio compatibility.

CryptoCompare API endpoints are simplified. Old variants with appended variables still work.

It also fixes the installation issue where the crypto_compare/apis directory would not be installed by using find_packages to automatically take care of package inclusion.